### PR TITLE
MH Upgrade to use Gradle 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 5
         versionName "3.1.1"
     }
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/library/src/main/java/com/activeandroid/Cache.java
+++ b/library/src/main/java/com/activeandroid/Cache.java
@@ -56,11 +56,18 @@ public final class Cache {
 	// PUBLIC METHODS
 	//////////////////////////////////////////////////////////////////////////////////////
 
-	public static synchronized void initialize(Configuration configuration) {
-		if (sIsInitialized) {
-			Log.v("ActiveAndroid already initialized.");
-			return;
-		}
+    public static synchronized void initialize(Configuration configuration) {
+        /**
+         * Since gradle plugin 2.0.0 and above, for some reason, initialize method get called from
+         * ContentProvider class (with no models in the configuration) before being initialized from
+         * the App context (with the modelsInfo). An extra check on the tableInfos collection size
+         * was necessary to make sure we have the models tables initialized.
+         * @author Maher Hanafi (mhanafi@ebates.com)
+         */
+        if (sIsInitialized && sModelInfo.getTableInfos().size() > 0) {
+            Log.v("ActiveAndroid already initialized and tables.");
+            return;
+        }
 
 		sContext = configuration.getContext();
 		sModelInfo = new ModelInfo(configuration);


### PR DESCRIPTION
Minor fix here in Cache.java to avoid the following issue:
**Attempt to invoke virtual method 'java.lang.String com.activeandroid.TableInfo.getTableName()' on a null object reference**
https://github.com/pardom/ActiveAndroid/issues/474

@vhuynh @mineshpatel1511 Please take a look at this.
This will be needed to use Android Studio 2.x and Instant Run